### PR TITLE
Fixes multiple switches

### DIFF
--- a/examples/common/utils.js
+++ b/examples/common/utils.js
@@ -76,7 +76,7 @@ FPS.prototype.update = function() {
 
 var switches = {};
 
-d3.select("[data-switch]").each(function(s) {
+d3.selectAll("[data-switch]").each(function(s) {
     var name = d3.select(this).attr("data-switch");
     var modes = d3.select(this).selectAll("[data-value]");
     var valueDefault = modes.filter(".active").attr("data-value");


### PR DESCRIPTION
Using `select` only the first switch section is ever selected, using `selectAll` fixes this and allows multiple switches.